### PR TITLE
Mock database transactions

### DIFF
--- a/src/EntityFrameworkCoreMock.Moq/DbContextMock.cs
+++ b/src/EntityFrameworkCoreMock.Moq/DbContextMock.cs
@@ -10,7 +10,10 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Moq;
 
 namespace EntityFrameworkCoreMock
@@ -61,6 +64,13 @@ namespace EntityFrameworkCoreMock
             Setup(x => x.SaveChanges()).Returns(SaveChanges);
             Setup(x => x.SaveChangesAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(SaveChanges);
             Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(SaveChanges);
+
+            var mockDbFacade = new Mock<DatabaseFacade>(Object);
+            var mockTransaction = new Mock<IDbContextTransaction>();
+            mockDbFacade.Setup(x => x.BeginTransaction()).Returns(mockTransaction.Object);
+            mockDbFacade.Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(mockTransaction.Object));
+            Setup(x => x.Database).Returns(mockDbFacade.Object);
         }
 
         // Facilitates unit-testing

--- a/src/EntityFrameworkCoreMock.NSubstitute/DbContextMock.cs
+++ b/src/EntityFrameworkCoreMock.NSubstitute/DbContextMock.cs
@@ -11,6 +11,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using NSubstitute;
 
 namespace EntityFrameworkCoreMock.NSubstitute
@@ -31,6 +32,7 @@ namespace EntityFrameworkCoreMock.NSubstitute
         private DbContextMock(IKeyFactoryBuilder keyFactoryBuilder, params object[] args)
         {
             Object = Substitute.For<TDbContext>(args);
+            Object.Database.Returns(Substitute.For<DatabaseFacade>(Object));
             _keyFactoryBuilder = keyFactoryBuilder ?? throw new ArgumentNullException(nameof(keyFactoryBuilder));
             Reset();
         }

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
@@ -218,6 +218,25 @@ namespace EntityFrameworkCoreMock.Tests
             var dbSet = dbContextMock.Object.Set<User>();
             Assert.That(dbSet.AsQueryable(), Is.Not.Null);
         }
+        
+        [Test]
+        public void DbContextMock_BeginTransaction_CommitTransaction_ShouldNotFail()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            Assert.DoesNotThrow(() =>
+            {
+                var transaction = dbContextMock.Object.Database.BeginTransaction();
+                transaction.Commit();
+                transaction.Rollback();
+            });
+            
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                var transaction = await dbContextMock.Object.Database.BeginTransactionAsync();
+                await transaction.CommitAsync();
+                await transaction.RollbackAsync();
+            });
+        }
 
         public class TestDbSetMock : IDbSetMock
         {

--- a/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbContextMockTests.cs
@@ -272,6 +272,25 @@ namespace EntityFrameworkCoreMock.NSubstitute.Tests
             Assert.That(dbSet, Is.Not.Null);
             Assert.That(dbSet, Is.EqualTo(dbSetMock.Object));
         }
+        
+        [Test]
+        public void DbContextMock_BeginTransaction_CommitTransaction_ShouldNotFail()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            Assert.DoesNotThrow(() =>
+            {
+                var transaction = dbContextMock.Object.Database.BeginTransaction();
+                transaction.Commit();
+                transaction.Rollback();
+            });
+            
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                var transaction = await dbContextMock.Object.Database.BeginTransactionAsync();
+                await transaction.CommitAsync();
+                await transaction.RollbackAsync();
+            });
+        }
 
         public class TestDbSetMock : IDbSetMock
         {


### PR DESCRIPTION
I would like to be able to test this kind of code:
```c#
using var transaction = await _dbContext.Database.BeginTransactionAsync();
_dbContext.Add(new Entity());
await _dbContext.SaveChangesAsync();
await transaction.CommitAsync();
```` 

However, it will fails because `_dbContext.Database` is `null`. 
```
System.NullReferenceException: Object reference not set to an instance of an object.
```

This PR will ensure that a `DatabaseFacade` mock is ready to be leveraged.
