### PR TITLE
Allow additional configuration of DbContextMock

### DIFF
--- a/src/EntityFrameworkCoreMock.Moq/DbContextMock.cs
+++ b/src/EntityFrameworkCoreMock.Moq/DbContextMock.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -78,9 +77,8 @@ namespace EntityFrameworkCoreMock
             var mockDbFacade = new Mock<DatabaseFacade>(context.Object);
             var mockTransaction = new Mock<IDbContextTransaction>();
             mockDbFacade.Setup(x => x.BeginTransaction()).Returns(mockTransaction.Object);
-
             mockDbFacade.Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(mockTransaction.Object));
+                .ReturnsAsync(mockTransaction.Object);
             context.Setup(x => x.Database).Returns(mockDbFacade.Object);
         }
 

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
@@ -268,7 +268,11 @@ namespace EntityFrameworkCoreMock.Tests
         public void DbContextMock_Constructor_WhenPassingCustomConfiguration_WithInterfaceSetup_UsesTheSetup()
         {
             var stateManager = Mock.Of<IStateManager>();
-            var dbContextMock = new DbContextMock<TestDbContext>(x => ConfigureAsDbContextDependencies(x, stateManager), Options);
+            var dbContextMock = new DbContextMock<TestDbContext>(x =>
+            {
+                ConfigureAsDbContextDependencies(x, stateManager);
+                DbContextMock<TestDbContext>.ConfigureTransaction(x);
+            }, Options);
 
             Assert.That(((IDbContextDependencies)dbContextMock.Object).StateManager, Is.EqualTo(stateManager));
         }


### PR DESCRIPTION
This PR solves my issue #39. It allows me to pass in my own configuration, which does not use the Object. 
P.S. In 90% of cases it would be enough to use `Of<DbContext>` as argument for DatabaseFacade's constructor. But I didn't want to impact original solution. By default, this will work as it worked, there is no impact for others as this just adds additional possibilities.