### PR TITLE
Add possibility to set global filters on DbSet

### DIFF
--- a/src/EntityFrameworkCoreMock.Moq/DbSetMock.cs
+++ b/src/EntityFrameworkCoreMock.Moq/DbSetMock.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -22,8 +23,14 @@ namespace EntityFrameworkCoreMock
         private readonly DbSetBackingStore<TEntity> _store;
 
         public DbSetMock(IEnumerable<TEntity> initialEntities, Func<TEntity, KeyContext, object> keyFactory, bool asyncQuerySupport = true)
+            : this(new DbSetBackingStore<TEntity>(initialEntities, keyFactory), asyncQuerySupport) { }
+
+        public DbSetMock(IEnumerable<TEntity> initialEntities, Func<TEntity, KeyContext, object> keyFactory, Expression<Func<TEntity, bool>> globalQueryFilter, bool asyncQuerySupport = true)
+            : this(new DbSetWithGlobalFilterBackingStore<TEntity>(initialEntities, keyFactory, globalQueryFilter), asyncQuerySupport) { }
+
+        public DbSetMock(DbSetBackingStore<TEntity> store, bool asyncQuerySupport = true)
         {
-            _store = new DbSetBackingStore<TEntity>(initialEntities, keyFactory);
+            _store = store;
 
             var data = _store.GetDataAsQueryable();
             As<IQueryable<TEntity>>().Setup(x => x.Provider).Returns(asyncQuerySupport ? new DbAsyncQueryProvider<TEntity>(data.Provider) : data.Provider);

--- a/src/EntityFrameworkCoreMock.Shared/DbSetWithGlobalFilterBackingStore.cs
+++ b/src/EntityFrameworkCoreMock.Shared/DbSetWithGlobalFilterBackingStore.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright 2017-2021 Wouter Huysentruit
+ *
+ * See LICENSE file.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace EntityFrameworkCoreMock
+{
+    public class DbSetWithGlobalFilterBackingStore<TEntity> : DbSetBackingStore<TEntity>
+        where TEntity : class
+    {
+        private Func<TEntity, bool> _compiledGlobalQueryFilter;
+        private Func<TEntity, bool> CompiledGlobalQueryFilter => _compiledGlobalQueryFilter ??= _globalQueryFilter.Compile();
+
+        private readonly Expression<Func<TEntity, bool>> _globalQueryFilter;
+
+        public DbSetWithGlobalFilterBackingStore(IEnumerable<TEntity> initialEntities, Func<TEntity, KeyContext, object> keyFactory, Expression<Func<TEntity, bool>> globalQueryFilter)
+            : base(initialEntities, keyFactory) =>
+            _globalQueryFilter = globalQueryFilter;
+
+        public override IQueryable<TEntity> GetDataAsQueryable() => base.GetDataAsQueryable().Where(_globalQueryFilter);
+
+        public override TEntity Find(object[] keyValues)
+        {
+            var entity = base.Find(keyValues);
+            if (entity != null && CompiledGlobalQueryFilter(entity))
+            {
+                return entity;
+            }
+            return null;
+        }
+    }
+}

--- a/src/EntityFrameworkCoreMock.Shared/KeyFactoryBuilders/KeyFactoryBuilderBase.cs
+++ b/src/EntityFrameworkCoreMock.Shared/KeyFactoryBuilders/KeyFactoryBuilderBase.cs
@@ -32,18 +32,15 @@ namespace EntityFrameworkCoreMock.Shared.KeyFactoryBuilders
             var databaseGeneratedAttribute = keyProperty.GetCustomAttribute(typeof(DatabaseGeneratedAttribute)) as DatabaseGeneratedAttribute;
             if (databaseGeneratedAttribute?.DatabaseGeneratedOption != DatabaseGeneratedOption.Identity) return null;
 
-            var entityArgument = Expression.Parameter(typeof(T));
-            var keyContextArgument = Expression.Parameter(typeof(KeyContext));
-
             if (keyProperty.PropertyType == typeof(int))
             {
                 return BuildIdentityKeyFactory<T, int>(keyProperty, ctx => Expression.Property(ctx, nameof(KeyContext.NextIdentity)));
             }
-            else if (keyProperty.PropertyType == typeof(long))
+            if (keyProperty.PropertyType == typeof(long))
             {
                 return BuildIdentityKeyFactory<T, long>(keyProperty, ctx => Expression.Property(ctx, nameof(KeyContext.NextIdentity)));
             }
-            else if (keyProperty.PropertyType == typeof(Guid))
+            if (keyProperty.PropertyType == typeof(Guid))
             {
                 return BuildIdentityKeyFactory<T, Guid>(keyProperty, _ => Expression.Call(typeof(Guid), nameof(Guid.NewGuid), Array.Empty<Type>()));
             }


### PR DESCRIPTION
This PR allows others to create custom backing stores for the DbSetMock, which allows to support global filters. EF only supports one global filter, so it's safe to be able to pass only one. Because it's optional - it doesn't impact any existing users either. We have a heavy use of global filters, so we found the need for such thing, because it's bad when you can't check if your global filters work fine. 
This PR also adds two setups on DbContextMock. When adding/removing to/from the context, it will call appropriate DbSetMock action. 

And also, usage of `var setter = propertyInfo.GetSetMethod(true);` in Clone function of `DbSetBackingStore` allows to use private setters when cloning the values. Because currently it's not possible to use private setters (which EF supports).