### PR TITLE
Support private property setters when cloning values

### DIFF
--- a/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
+++ b/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
@@ -189,7 +189,7 @@ namespace EntityFrameworkCoreMock
         {
             var properties = entityType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Where(x => x.CanRead && x.CanWrite && x.GetCustomAttribute<NotMappedAttribute>() == null)
-                .Where(x => x.GetSetMethod() != null)
+                .Where(x => x.GetSetMethod(true) != null)
                 .ToArray();
 
             var original = Expression.Parameter(typeof(TEntity), "original");
@@ -202,7 +202,7 @@ namespace EntityFrameworkCoreMock
                     properties.Select(propertyInfo =>
                     {
                         var getter = Expression.Property(Expression.Convert(original, entityType), propertyInfo);
-                        var setter = propertyInfo.GetSetMethod();
+                        var setter = propertyInfo.GetSetMethod(true);
                         return Expression.Call(clone, setter, getter);
                     })
                 ),

--- a/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
+++ b/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
@@ -189,7 +189,7 @@ namespace EntityFrameworkCoreMock
         {
             var properties = entityType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Where(x => x.CanRead && x.CanWrite && x.GetCustomAttribute<NotMappedAttribute>() == null)
-                .Where(x => x.GetSetMethod(true) != null)
+                .Where(x => x.GetSetMethod(nonPublic: true) != null)
                 .ToArray();
 
             var original = Expression.Parameter(typeof(TEntity), "original");

--- a/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
+++ b/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
@@ -202,7 +202,7 @@ namespace EntityFrameworkCoreMock
                     properties.Select(propertyInfo =>
                     {
                         var getter = Expression.Property(Expression.Convert(original, entityType), propertyInfo);
-                        var setter = propertyInfo.GetSetMethod(true);
+                        var setter = propertyInfo.GetSetMethod(nonPublic: true);
                         return Expression.Call(clone, setter, getter);
                     })
                 ),

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/DbSetMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/DbSetMockTests.cs
@@ -39,7 +39,7 @@ namespace EntityFrameworkCoreMock.Tests
         [Test]
         public void DbSetMock_GivenEntityIsAdded_ShouldAddAfterCallingSaveChanges()
         {
-            var user = new User {Id = Guid.NewGuid(), FullName = "Fake Drake"};
+            var user = new User { Id = Guid.NewGuid(), FullName = "Fake Drake" };
             var dbSetMock = new DbSetMock<User>(null, (x, _) => x.Id);
             var dbSet = dbSetMock.Object;
 
@@ -105,7 +105,7 @@ namespace EntityFrameworkCoreMock.Tests
             var dbSet = dbSetMock.Object;
 
             // Act
-            dbSet.UpdateRange(new []
+            dbSet.UpdateRange(new[]
             {
                 new User { Id = users[0].Id, FullName = "Ian Kilmister AAA" },
                 new User { Id = users[1].Id, FullName = "Phil Taylor AAA" },
@@ -136,7 +136,7 @@ namespace EntityFrameworkCoreMock.Tests
         [Test]
         public void DbSetMock_GivenEntityIsRemoved_ShouldRemoveAfterCallingSaveChanges()
         {
-            var user = new User {Id = Guid.NewGuid(), FullName = "Fake Drake"};
+            var user = new User { Id = Guid.NewGuid(), FullName = "Fake Drake" };
             var dbSetMock = new DbSetMock<User>(new[]
             {
                 user,
@@ -145,7 +145,7 @@ namespace EntityFrameworkCoreMock.Tests
             var dbSet = dbSetMock.Object;
 
             Assert.That(dbSet.Count(), Is.EqualTo(2));
-            dbSet.Remove(new User {Id = user.Id});
+            dbSet.Remove(new User { Id = user.Id });
             Assert.That(dbSet.Count(), Is.EqualTo(2));
             Assert.That(dbSet.Any(x => x.Id == user.Id && x.FullName == user.FullName), Is.True);
             ((IDbSetMock)dbSetMock).SaveChanges();
@@ -382,6 +382,18 @@ namespace EntityFrameworkCoreMock.Tests
         public class ConcreteModel : AbstractModel
         {
             public string Name { get; set; } = "SomeName";
+        }
+
+        [Test]
+        public void DbSetMock_WithPrivateProperty_ShouldCopyIt()
+        {
+            var dbSetMock = new DbSetMock<PrivateSetterPropertyModel>(new[]
+            {
+                new PrivateSetterPropertyModel("my value")
+            }, (x, _) => x.Private);
+
+            var dbSet = dbSetMock.Object;
+            Assert.That(dbSet.First().Private, Is.EqualTo("my value"));
         }
     }
 }

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/DbSetMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/DbSetMockTests.cs
@@ -385,7 +385,7 @@ namespace EntityFrameworkCoreMock.Tests
         }
 
         [Test]
-        public void DbSetMock_WithPrivateProperty_ShouldCopyIt()
+        public void DbSetMock_ModelPropertyWithPrivateSetter_ShouldSetTheProperty()
         {
             var dbSetMock = new DbSetMock<PrivateSetterPropertyModel>(new[]
             {

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/Models/PrivateSetterPropertyModel.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/Models/PrivateSetterPropertyModel.cs
@@ -1,0 +1,14 @@
+﻿namespace EntityFrameworkCoreMock.Tests.Models
+{
+    public class PrivateSetterPropertyModel
+    {
+        private PrivateSetterPropertyModel() { }
+
+        public PrivateSetterPropertyModel(string value)
+        {
+            Private = value;
+        }
+
+        public string Private { get; private set; }
+    }
+}

--- a/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbSetMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbSetMockTests.cs
@@ -98,7 +98,7 @@ namespace EntityFrameworkCoreMock.NSubstitute.Tests
             var dbSet = dbSetMock.Object;
 
             // Act
-            dbSet.UpdateRange(new []
+            dbSet.UpdateRange(new[]
             {
                 new User { Id = users[0].Id, FullName = "Ian Kilmister AAA" },
                 new User { Id = users[1].Id, FullName = "Phil Taylor AAA" },
@@ -375,6 +375,18 @@ namespace EntityFrameworkCoreMock.NSubstitute.Tests
         public class ConcreteModel : AbstractModel
         {
             public string Name { get; set; } = "SomeName";
+        }
+
+        [Test]
+        public void DbSetMock_WithPrivateProperty_ShouldCopyIt()
+        {
+            var dbSetMock = new DbSetMock<PrivateSetterPropertyModel>(new[]
+            {
+                new PrivateSetterPropertyModel("my value")
+            }, (x, _) => x.Private);
+
+            var dbSet = dbSetMock.Object;
+            Assert.That(dbSet.First().Private, Is.EqualTo("my value"));
         }
     }
 }

--- a/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbSetMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbSetMockTests.cs
@@ -378,7 +378,7 @@ namespace EntityFrameworkCoreMock.NSubstitute.Tests
         }
 
         [Test]
-        public void DbSetMock_WithPrivateProperty_ShouldCopyIt()
+        public void DbSetMock_ModelPropertyWithPrivateSetter_ShouldSetTheProperty()
         {
             var dbSetMock = new DbSetMock<PrivateSetterPropertyModel>(new[]
             {

--- a/tests/EntityFrameworkCoreMock.NSubstitute.Tests/Models/PrivateSetterPropertyModel.cs
+++ b/tests/EntityFrameworkCoreMock.NSubstitute.Tests/Models/PrivateSetterPropertyModel.cs
@@ -1,0 +1,14 @@
+﻿namespace EntityFrameworkCoreMock.Tests.Models
+{
+    public class PrivateSetterPropertyModel
+    {
+        private PrivateSetterPropertyModel() { }
+
+        public PrivateSetterPropertyModel(string value)
+        {
+            Private = value;
+        }
+
+        public string Private { get; private set; }
+    }
+}


### PR DESCRIPTION
In EF, you can have private property setters in your model and it is able to set them. This was not possible with this library, so adding support for that.