### PR TITLE
Add AddAsync and Update setups on DbContextMock

### DIFF
--- a/src/EntityFrameworkCoreMock.Moq/DbContextMock.cs
+++ b/src/EntityFrameworkCoreMock.Moq/DbContextMock.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -50,10 +49,10 @@ namespace EntityFrameworkCoreMock
             var mock = new DbSetMock<TEntity>(initialEntities, entityKeyFactory);
             Setup(dbSetSelector).Returns(() => mock.Object);
             Setup(x => x.Set<TEntity>()).Returns(() => mock.Object);
-            Setup(x => x.Add(It.IsAny<TEntity>()))
-                .Callback<TEntity>(entity => mock.Object.Add(entity));
-            Setup(x => x.Remove(It.IsAny<TEntity>()))
-                .Callback<TEntity>(entity => mock.Object.Remove(entity));
+            Setup(x => x.Add(It.IsAny<TEntity>())).Callback<TEntity>(entity => mock.Object.Add(entity));
+            Setup(x => x.AddAsync(It.IsAny<TEntity>(), It.IsAny<CancellationToken>())).Callback<TEntity, CancellationToken>((entity, token) => mock.Object.AddAsync(entity, token));
+            Setup(x => x.Update(It.IsAny<TEntity>())).Callback<TEntity>(entity => mock.Object.Update(entity));
+            Setup(x => x.Remove(It.IsAny<TEntity>())).Callback<TEntity>(entity => mock.Object.Remove(entity));
             _dbSetCache.Add(entityType, mock);
             return mock;
         }
@@ -77,6 +76,12 @@ namespace EntityFrameworkCoreMock
             });
 
             Setup(x => x.Database).Returns(() => lazyMockDbFacade.Value.Object);
+            Setup(x => x.AddRange(It.IsAny<object[]>())).Callback<object[]>(entities =>
+            {
+
+
+                //Object.AddRange((IEnumerable<object>)entities);
+            });
         }
 
         // Facilitates unit-testing

--- a/src/EntityFrameworkCoreMock.Moq/DbContextMock.cs
+++ b/src/EntityFrameworkCoreMock.Moq/DbContextMock.cs
@@ -76,12 +76,6 @@ namespace EntityFrameworkCoreMock
             });
 
             Setup(x => x.Database).Returns(() => lazyMockDbFacade.Value.Object);
-            Setup(x => x.AddRange(It.IsAny<object[]>())).Callback<object[]>(entities =>
-            {
-
-
-                //Object.AddRange((IEnumerable<object>)entities);
-            });
         }
 
         // Facilitates unit-testing

--- a/src/EntityFrameworkCoreMock.NSubstitute/DbContextMock.cs
+++ b/src/EntityFrameworkCoreMock.NSubstitute/DbContextMock.cs
@@ -53,16 +53,9 @@ namespace EntityFrameworkCoreMock.NSubstitute
             var mock = new DbSetMock<TEntity>(initialEntities, entityKeyFactory);
             Object.Set<TEntity>().Returns(mock.Object);
             Object.Add<TEntity>(Arg.Any<TEntity>()).Returns(callInfo => mock.Object.Add(callInfo.Arg<TEntity>()));
+            Object.AddAsync<TEntity>(Arg.Any<TEntity>()).Returns(callInfo => mock.Object.AddAsync(callInfo.Arg<TEntity>()));
+            Object.Update<TEntity>(Arg.Any<TEntity>()).Returns(callInfo => mock.Object.Update(callInfo.Arg<TEntity>()));
             Object.Remove<TEntity>(Arg.Any<TEntity>()).Returns(callInfo => mock.Object.Remove(callInfo.Arg<TEntity>()));
-
-            Object.When(a => a.Add(Arg.Any<TEntity>())).Do(b => mock.Object.Add(b.ArgAt<TEntity>(0)));
-            Object.When(a => a.AddAsync(Arg.Any<TEntity>())).Do(b => mock.Object.AddAsync(b.ArgAt<TEntity>(0)));
-
-            Object.When(a => a.AddRange(Arg.Any<IEnumerable<TEntity>>())).Do(b => mock.Object.AddRange(b.ArgAt<IEnumerable<TEntity>>(0)));
-            Object.When(a => a.AddRangeAsync(Arg.Any<IEnumerable<TEntity>>())).Do(b => mock.Object.AddRangeAsync(b.ArgAt<IEnumerable<TEntity>>(0)));
-
-            Object.When(a => a.Remove(Arg.Any<TEntity>())).Do(b => mock.Object.Remove(b.ArgAt<TEntity>(0)));
-            Object.When(a => a.RemoveRange(Arg.Any<IEnumerable<TEntity>>())).Do(b => mock.Object.RemoveRange(b.ArgAt<IEnumerable<TEntity>>(0)));
 
             dbSetSelector.Compile()(Object).Returns(mock.Object);
 

--- a/src/EntityFrameworkCoreMock.NSubstitute/DbContextMock.cs
+++ b/src/EntityFrameworkCoreMock.NSubstitute/DbContextMock.cs
@@ -53,6 +53,15 @@ namespace EntityFrameworkCoreMock.NSubstitute
             var mock = new DbSetMock<TEntity>(initialEntities, entityKeyFactory);
             Object.Set<TEntity>().Returns(mock.Object);
 
+            Object.When(a => a.Add(Arg.Any<TEntity>())).Do(b => mock.Object.Add(b.ArgAt<TEntity>(0)));
+            Object.When(a => a.AddAsync(Arg.Any<TEntity>())).Do(b => mock.Object.AddAsync(b.ArgAt<TEntity>(0)));
+
+            Object.When(a => a.AddRange(Arg.Any<IEnumerable<TEntity>>())).Do(b => mock.Object.AddRange(b.ArgAt<IEnumerable<TEntity>>(0)));
+            Object.When(a => a.AddRangeAsync(Arg.Any<IEnumerable<TEntity>>())).Do(b => mock.Object.AddRangeAsync(b.ArgAt<IEnumerable<TEntity>>(0)));
+
+            Object.When(a => a.Remove(Arg.Any<TEntity>())).Do(b => mock.Object.Remove(b.ArgAt<TEntity>(0)));
+            Object.When(a => a.RemoveRange(Arg.Any<IEnumerable<TEntity>>())).Do(b => mock.Object.RemoveRange(b.ArgAt<IEnumerable<TEntity>>(0)));
+
             dbSetSelector.Compile()(Object).Returns(mock.Object);
 
             _dbSetCache.Add(entityType, mock);

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
@@ -267,6 +267,40 @@ namespace EntityFrameworkCoreMock.Tests
         }
 
         [Test]
+        public async Task DbContextMock_AddAsync_ShouldAddEntity()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var user = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            dbContextMock.CreateDbSetMock(x => x.Users, Array.Empty<User>());
+
+            await dbContextMock.Object.AddAsync(user);
+            await dbContextMock.Object.SaveChangesAsync();
+
+            var dbSet = dbContextMock.Object.Users;
+            Assert.That(dbSet.Count(), Is.EqualTo(1));
+            var actualUser = dbSet.First();
+            Assert.That(actualUser, Is.Not.Null);
+            Assert.That(actualUser.FullName, Is.EqualTo("Mark Kramer"));
+        }
+
+        [Test]
+        public void DbContextMock_Update_ShouldUpdateEntity()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var user = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            dbContextMock.CreateDbSetMock(x => x.Users, new[] { user });
+
+            dbContextMock.Object.Update(new User { Id = user.Id, FullName = "Updated name" });
+            dbContextMock.Object.SaveChanges();
+
+            var dbSet = dbContextMock.Object.Users;
+            Assert.That(dbSet.Count(), Is.EqualTo(1));
+            var actualUser = dbSet.First();
+            Assert.That(actualUser, Is.Not.Null);
+            Assert.That(actualUser.FullName, Is.EqualTo("Updated name"));
+        }
+
+        [Test]
         public void DbContextMock_Remove_ShouldRemoveEntity()
         {
             var dbContextMock = new DbContextMock<TestDbContext>(Options);

--- a/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbContextMockTests.cs
@@ -300,6 +300,111 @@ namespace EntityFrameworkCoreMock.NSubstitute.Tests
             });
         }
 
+        [Test]
+        public void DbContextMock_Add_ShouldAddEntity()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var user = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            dbContextMock.CreateDbSetMock(x => x.Users, Array.Empty<User>());
+
+            dbContextMock.Object.Add(user);
+            dbContextMock.Object.SaveChanges();
+
+            var dbSet = dbContextMock.Object.Users;
+            Assert.That(dbSet.Count(), Is.EqualTo(1));
+            var actualUser = dbSet.First();
+            Assert.That(actualUser, Is.Not.Null);
+            Assert.That(actualUser.FullName, Is.EqualTo("Mark Kramer"));
+        }
+
+        [Test]
+        public async Task DbContextMock_AddAsync_ShouldAddEntity()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var user = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            dbContextMock.CreateDbSetMock(x => x.Users, Array.Empty<User>());
+
+            await dbContextMock.Object.AddAsync(user);
+            await dbContextMock.Object.SaveChangesAsync();
+
+            var dbSet = dbContextMock.Object.Users;
+            Assert.That(dbSet.Count(), Is.EqualTo(1));
+            var actualUser = dbSet.First();
+            Assert.That(actualUser, Is.Not.Null);
+            Assert.That(actualUser.FullName, Is.EqualTo("Mark Kramer"));
+        }
+
+        [Test]
+        public void DbContextMock_AddRange_ShouldAddEntity()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var user1 = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            var user2 = new User { Id = Guid.NewGuid(), FullName = "Some other user" };
+            dbContextMock.CreateDbSetMock(x => x.Users, Array.Empty<User>());
+
+            dbContextMock.Object.AddRange(new[] { user1, user2 }.AsEnumerable());
+            dbContextMock.Object.SaveChanges();
+
+            var dbSet = dbContextMock.Object.Users;
+            Assert.That(dbSet.Count(), Is.EqualTo(2));
+            var firstUser = dbSet.First();
+            Assert.That(firstUser, Is.Not.Null);
+            Assert.That(firstUser.FullName, Is.EqualTo("Mark Kramer"));
+            var secondUser = dbSet.Last();
+            Assert.That(secondUser, Is.Not.Null);
+            Assert.That(secondUser.FullName, Is.EqualTo("Some other user"));
+        }
+
+        [Test]
+        public async Task DbContextMock_AddRangeAsync_ShouldAddEntity()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var user1 = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            var user2 = new User { Id = Guid.NewGuid(), FullName = "Some other user" };
+            dbContextMock.CreateDbSetMock(x => x.Users, Array.Empty<User>());
+
+            await dbContextMock.Object.AddRangeAsync(new[] { user1, user2 }.AsEnumerable());
+            await dbContextMock.Object.SaveChangesAsync();
+
+            var dbSet = dbContextMock.Object.Users;
+            Assert.That(dbSet.Count(), Is.EqualTo(2));
+            var firstUser = dbSet.First();
+            Assert.That(firstUser, Is.Not.Null);
+            Assert.That(firstUser.FullName, Is.EqualTo("Mark Kramer"));
+            var secondUser = dbSet.Last();
+            Assert.That(secondUser, Is.Not.Null);
+            Assert.That(secondUser.FullName, Is.EqualTo("Some other user"));
+        }
+
+        [Test]
+        public void DbContextMock_Remove_ShouldRemoveEntity()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var user = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            dbContextMock.CreateDbSetMock(x => x.Users, new[] { user });
+
+            dbContextMock.Object.Remove(user);
+            dbContextMock.Object.SaveChanges();
+
+            var dbSet = dbContextMock.Object.Users;
+            Assert.That(dbSet.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void DbContextMock_RemoveRange_ShouldRemoveEntity()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var user1 = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            var user2 = new User { Id = Guid.NewGuid(), FullName = "Some other user" };
+            dbContextMock.CreateDbSetMock(x => x.Users, new[] { user1, user2 });
+
+            dbContextMock.Object.RemoveRange(new[] { user1, user2 }.AsEnumerable());
+            dbContextMock.Object.SaveChanges();
+
+            var dbSet = dbContextMock.Object.Users;
+            Assert.That(dbSet.Count(), Is.EqualTo(0));
+        }
+
         public class TestDbSetMock : IDbSetMock
         {
             public int SaveChanges() => 55861;

--- a/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.NSubstitute.Tests/DbContextMockTests.cs
@@ -335,45 +335,20 @@ namespace EntityFrameworkCoreMock.NSubstitute.Tests
         }
 
         [Test]
-        public void DbContextMock_AddRange_ShouldAddEntity()
+        public void DbContextMock_Update_ShouldUpdateEntity()
         {
             var dbContextMock = new DbContextMock<TestDbContext>(Options);
-            var user1 = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
-            var user2 = new User { Id = Guid.NewGuid(), FullName = "Some other user" };
-            dbContextMock.CreateDbSetMock(x => x.Users, Array.Empty<User>());
+            var user = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
+            dbContextMock.CreateDbSetMock(x => x.Users, new[] { user });
 
-            dbContextMock.Object.AddRange(new[] { user1, user2 }.AsEnumerable());
+            dbContextMock.Object.Update(new User { Id = user.Id, FullName = "Updated name" });
             dbContextMock.Object.SaveChanges();
 
             var dbSet = dbContextMock.Object.Users;
-            Assert.That(dbSet.Count(), Is.EqualTo(2));
-            var firstUser = dbSet.First();
-            Assert.That(firstUser, Is.Not.Null);
-            Assert.That(firstUser.FullName, Is.EqualTo("Mark Kramer"));
-            var secondUser = dbSet.Last();
-            Assert.That(secondUser, Is.Not.Null);
-            Assert.That(secondUser.FullName, Is.EqualTo("Some other user"));
-        }
-
-        [Test]
-        public async Task DbContextMock_AddRangeAsync_ShouldAddEntity()
-        {
-            var dbContextMock = new DbContextMock<TestDbContext>(Options);
-            var user1 = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
-            var user2 = new User { Id = Guid.NewGuid(), FullName = "Some other user" };
-            dbContextMock.CreateDbSetMock(x => x.Users, Array.Empty<User>());
-
-            await dbContextMock.Object.AddRangeAsync(new[] { user1, user2 }.AsEnumerable());
-            await dbContextMock.Object.SaveChangesAsync();
-
-            var dbSet = dbContextMock.Object.Users;
-            Assert.That(dbSet.Count(), Is.EqualTo(2));
-            var firstUser = dbSet.First();
-            Assert.That(firstUser, Is.Not.Null);
-            Assert.That(firstUser.FullName, Is.EqualTo("Mark Kramer"));
-            var secondUser = dbSet.Last();
-            Assert.That(secondUser, Is.Not.Null);
-            Assert.That(secondUser.FullName, Is.EqualTo("Some other user"));
+            Assert.That(dbSet.Count(), Is.EqualTo(1));
+            var actualUser = dbSet.First();
+            Assert.That(actualUser, Is.Not.Null);
+            Assert.That(actualUser.FullName, Is.EqualTo("Updated name"));
         }
 
         [Test]
@@ -384,21 +359,6 @@ namespace EntityFrameworkCoreMock.NSubstitute.Tests
             dbContextMock.CreateDbSetMock(x => x.Users, new[] { user });
 
             dbContextMock.Object.Remove(user);
-            dbContextMock.Object.SaveChanges();
-
-            var dbSet = dbContextMock.Object.Users;
-            Assert.That(dbSet.Count(), Is.EqualTo(0));
-        }
-
-        [Test]
-        public void DbContextMock_RemoveRange_ShouldRemoveEntity()
-        {
-            var dbContextMock = new DbContextMock<TestDbContext>(Options);
-            var user1 = new User { Id = Guid.NewGuid(), FullName = "Mark Kramer" };
-            var user2 = new User { Id = Guid.NewGuid(), FullName = "Some other user" };
-            dbContextMock.CreateDbSetMock(x => x.Users, new[] { user1, user2 });
-
-            dbContextMock.Object.RemoveRange(new[] { user1, user2 }.AsEnumerable());
             dbContextMock.Object.SaveChanges();
 
             var dbSet = dbContextMock.Object.Users;


### PR DESCRIPTION
Forgot to add AddAsync and Update setups. There are Range methods as well, but I found too difficult mocking them, as in some cases they work just fine, in some not and Moq even was a bit limited with that. 