### PR TITLE
Fixing issue #47: DBSetBackingStore.ApplyChanges always returns zero

### DIFF
--- a/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
+++ b/src/EntityFrameworkCoreMock.Shared/DbSetBackingStore.cs
@@ -100,7 +100,7 @@ namespace EntityFrameworkCoreMock
                 else if (change.IsRemove) RemoveEntity(change.Entity);
             }
 
-            return _changes.Count;
+            return changes.Count;
         }
 
         /// <summary>


### PR DESCRIPTION
`DBSetBackingStore.ApplyChanges` uses _`changes.Count` to return number of changes, _changes is always empty because `Interlocked.Exchange(ref _changes, new List<DbSetChange>())` is called before that.
suggested fix is to use `changes.Count` instead. (no underscores)

[Link to the issue](https://github.com/cup-of-tea-dot-be/entity-framework-core-mock/issues/47)