### PR TITLE
Fix generated key when initial entities have ids

### DIFF
--- a/src/EntityFrameworkCoreMock.Shared/KeyContext.cs
+++ b/src/EntityFrameworkCoreMock.Shared/KeyContext.cs
@@ -11,5 +11,11 @@ namespace EntityFrameworkCoreMock
         private long _nextIdentity = 1;
 
         public long NextIdentity => _nextIdentity++;
+
+        public long CurrentIdentity
+        {
+            get => _nextIdentity;
+            set => _nextIdentity = value + 1;
+        }
     }
 }

--- a/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
+++ b/tests/EntityFrameworkCoreMock.Moq.Tests/DbContextMockTests.cs
@@ -165,6 +165,25 @@ namespace EntityFrameworkCoreMock.Tests
             Assert.That(dbSetMock.Object.First(x => x.Id == 2).Value, Is.EqualTo("second"));
             Assert.That(dbSetMock.Object.First(x => x.Id == 3).Value, Is.EqualTo("third"));
         }
+        
+        [Test]
+        public void DbContextMock_CreateDbSetMock_AddWithDatabaseGeneratedIdentityKeyWithIdsOnInitialEntities_ShouldGenerateSequentialKey()
+        {
+            var dbContextMock = new DbContextMock<TestDbContext>(Options);
+            var dbSetMock = dbContextMock.CreateDbSetMock(x => x.GeneratedKeyModels, new[]
+            {
+                new GeneratedKeyModel {Id = 1, Value = "first"},
+                new GeneratedKeyModel {Id = 2, Value = "second"}
+            });
+            dbSetMock.Object.Add(new GeneratedKeyModel { Value = "third" });
+            dbContextMock.Object.SaveChanges();
+
+            Assert.That(dbSetMock.Object.Min(x => x.Id), Is.EqualTo(1));
+            Assert.That(dbSetMock.Object.Max(x => x.Id), Is.EqualTo(3));
+            Assert.That(dbSetMock.Object.First(x => x.Id == 1).Value, Is.EqualTo("first"));
+            Assert.That(dbSetMock.Object.First(x => x.Id == 2).Value, Is.EqualTo("second"));
+            Assert.That(dbSetMock.Object.First(x => x.Id == 3).Value, Is.EqualTo("third"));
+        }
 
         [Test]
         public void DbContextMock_CreateDbSetMock_AddMultipleModelsWithGuidAsDatabaseGeneratedIdentityKey_ShouldGenerateRandomGuidAsKey()


### PR DESCRIPTION
I have encountered an Issue, when an int or long key property is used and the MockDbSet has initial Entities with predefined key values.

This PR also includes a test for this case.

My idea was if a new Entity with a Key is added to set the KeyContext Identity value to the provided Key if it is larger than the current one.